### PR TITLE
Fix Iteration Bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME ?= inloco/kube-dumper
-IMAGE_VERSION ?= v1.1.1
+IMAGE_VERSION ?= v1.2.0
 
 docker: docker-build docker-push
 


### PR DESCRIPTION
The current implementation has a bug that drops the last item of some list when iterating over it. This caused some resources, types, and namespaces to not be backed up properly. Removing the argument `n` from `echo` fixes this problem.

```bash
$ kubectl get sa --output=json | jq -c '.items[]'

{"apiVersion":"v1","kind":"ServiceAccount","metadata":{"creationTimestamp":"2020-02-07T16:37:17Z","name":"default","namespace":"default","resourceVersion":"415619402","uid":"1ac4002a-49c8-11ea-ae5a-02ba5dd1291f"},"secrets":[{"name":"default-token-kkdxj"}]}
```

```bash
$ SA=$(kubectl get sa --output=json | jq -c '.items[]')
$ echo -En "${SA}" | while read -r E ; do echo "${E}" ; done

%
```

```bash
$ SA=$(kubectl get sa --output=json | jq -c '.items[]')
$ echo -E "${SA}" | while read -r E ; do echo "${E}" ; done

{"apiVersion":"v1","kind":"ServiceAccount","metadata":{"creationTimestamp":"2020-02-07T16:37:17Z","name":"default","namespace":"default","resourceVersion":"415619402","uid":"1ac4002a-49c8-11ea-ae5a-02ba5dd1291f"},"secrets":[{"name":"default-token-kkdxj"}]}
```

Additionally, some refactor was performed.